### PR TITLE
Update init templating

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: influxdata
 name: molecule
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.4.1
+version: 1.4.2-dev
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/init/defaults/main.yml
+++ b/roles/init/defaults/main.yml
@@ -10,7 +10,7 @@ init_platform_type: docker
 
 # Version of this collection that should be used by the Molecule test
 # - Set to "" to attempt to use the running version
-init_collection_version: ""
+init_collection_version: latest
 
 # Source of the collection that this role is part of (galaxy, git)
 init_collection_source: git

--- a/roles/init/defaults/main.yml
+++ b/roles/init/defaults/main.yml
@@ -42,6 +42,24 @@ init_platforms: []
 # Create backups of any files that would be clobbered by running this role
 init_file_backup: true
 
+# Default configuration to be added to generated molecule.yml if init_platforms is not defined
+init_platform_defaults:
+  docker:
+    - name: docker-rockylinux9
+      type: docker
+      config:
+        image: "geerlingguy/docker-rockylinux9-ansible:latest"
+        systemd: true
+  ec2:
+    - name: ec2-rockylinux9
+      type: ec2
+      config:
+        image: "ami-067daee80a6d36ac0"
+        instance_type: "t3.micro"
+        region: "us-east-2"
+        vpc_id: "vpc-12345678"
+        vpc_subnet_id: "subnet-12345678"
+
 # Path to the ansible secret file that should be used by the Molecule test
 #  - Variable substitution can be used as described here: https://ansible.readthedocs.io/projects/molecule/configuration/#variable-substitution
 #  - Set to "" to disable
@@ -49,8 +67,8 @@ init_ansible_secret_path: ""
 
 # Configuration defaults to be used if the collection manifest is not accessible
 init_collection_defaults:
-  repository: https://github.com/syndr/ansible-collection-molecule
+  repository: https://github.com/influxdata/ansible-collection-molecule
   name: molecule
-  namespace: syndr
+  namespace: influxdata
   version: latest
 

--- a/roles/init/files/init.yml
+++ b/roles/init/files/init.yml
@@ -12,4 +12,7 @@
         init_platform_type: docker
         # Supported collection sources are: git, galaxy
         init_collection_source: git
+        # Version of this collection that should be used by the Molecule test
+        # - Set to "" to attempt to use the running version
+        init_collection_version: latest
 

--- a/roles/init/tasks/main.yml
+++ b/roles/init/tasks/main.yml
@@ -10,30 +10,16 @@
 
 - name: Build base platform definition
   when: init_platforms is not truthy
-  # TODO: Define these values in the role defaults
   block:
     - name: Build base docker platform definition
       when: init_platform_type == 'docker'
       ansible.builtin.set_fact:
-        init_platforms:
-          - name: docker-rockylinux9
-            type: docker
-            config:
-              image: "geerlingguy/docker-rockylinux9-ansible:latest"
-              systemd: true
+        init_platforms: "{{ init_platforms | default(init_platform_defaults.docker) }}"
 
     - name: Build base ec2 platform definition
       when: init_platform_type == 'ec2'
       ansible.builtin.set_fact:
-        init_platforms:
-          - name: ec2-rockylinux9
-            type: ec2
-            config:
-              image: "ami-067daee80a6d36ac0"
-              instance_type: "t3.micro"
-              region: "us-east-2"
-              vpc_id: "vpc-12345678"
-              vpc_subnet_id: "subnet-12345678"
+        init_platforms: "{{ init_platforms | default(init_platform_defaults.ec2) }}"
 
     - name: Platform definition is valid
       ansible.builtin.assert:

--- a/roles/init/templates/molecule.yml.j2
+++ b/roles/init/templates/molecule.yml.j2
@@ -35,11 +35,13 @@ provisioner:
   name: ansible
   log: True
   playbooks:
+    create: create.yml
     prepare: prepare.yml
     converge: converge.yml
     side_effect: side_effect.yml
     verify: verify.yml
     cleanup: cleanup.yml
+    destroy: destroy.yml
   config_options:
     defaults:
       gathering: explicit

--- a/roles/init/templates/prepare.yml.j2
+++ b/roles/init/templates/prepare.yml.j2
@@ -13,7 +13,6 @@
 - name: Prepare target host for execution
   hosts: molecule
   tags: always
-  become: true
   tasks:
     ##
     # Creating an admin service account for Molecule/Ansible to use for testing
@@ -29,6 +28,7 @@
     ##
 {% raw %}
     - name: Create ansible service account
+      become: true
       vars:
         molecule_user: molecule_runner
       block:


### PR DESCRIPTION
Fixes some templating issues with the `init` role used to provision new Molecule scenarios.

Main points:
- Use `latest` tag for collection version by default
- Fix scope of `become` statement in `prepare.yml`
- Better handling of default values