### PR TITLE
Release CI fixes, `init` role templating fixes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,19 @@ jobs:
     if: |
       github.event.release.prerelase == false
     steps:
-      - uses: actions/checkout@v4
+      - name: Check deployment configuration
+        shell: bash
+        run: |
+          if [ -z "${{ secrets.GALAXY_API_KEY }}" ]; then
+            echo "No Galaxy API key found. Skipping deployment."
+            echo "GALAXY_DEPLOYMENT_ENABLED=1" >> $GITHUB_ENV
+          else
+            echo "Galaxy API key found. Deploying collection."
+            echo "GALAXY_DEPLOYMENT_ENABLED=0" >> $GITHUB_ENV
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
       - name: Tag latest release
         uses: EndBug/latest-tag@latest
@@ -24,7 +36,7 @@ jobs:
 
       - name: Build and Deploy Collection
         uses: artis3n/ansible_galaxy_collection@v2
-        if: ${{ secrets.GALAXY_API_KEY != '' }}
+        if: ${{ env.GALAXY_DEPLOYMENT_ENABLED == '0' }}
         with:
           api_key: '${{ secrets.GALAXY_API_KEY }}'
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *-molecule-*.tar.gz
+venv/

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: influxdata
 name: molecule
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 2.0.0
+version: 2.0.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/init/README.md
+++ b/roles/init/README.md
@@ -17,18 +17,16 @@ mkdir -p molecule/default
 
 ## Create the init playbook
 
-Within the new scenario directory (default), create a file `init.yml` containing the example playbook from this README.
+Within the new scenario directory (default), create a file `init.yml` containing the init playbook located at [files/init.yml](files/init.yml).
 
 Alternatively, you can run:
 ```bash
 wget -P molecule/default https://raw.githubusercontent.com/influxdata/ansible-collection-molecule/main/roles/init/files/init.yml
 ```
 
-Configuration variables for the `init` role launched by this playbook can be customized as desired.
-
 You should now have a directory structure similar to the following:
 ```
-ansible-role-users
+my_cool_role
 ├── defaults
 ├── molecule
 │   └── default
@@ -42,6 +40,11 @@ ansible-role-users
 └── vars
 ```
 
+
+## Edit the init playbook
+
+Edit the configuration variables as desired for your deployment.
+
 ## Run the init playbook
 
 ```bash
@@ -50,23 +53,35 @@ ansible-playbook molecule/default/init.yml
 
 You should now see that additional configuration has been added to the `default` scenario directory:  
 ```
-ansible-role-users
+my_cool_role
 ├── defaults
 ├── molecule
-│   └── default
+│   ├── resources
+│   │   ├── cleanup.yml
+│   │   ├── collections.yml
+│   │   ├── converge.yml
+│   │   ├── create.yml
+│   │   ├── destroy.yml
+│   │   ├── prepare.yml
+│   │   ├── requirements.yml
+│   │   ├── side_effect.yml
+│   │   └── verify.yml
+│   └── role-disks-docker
 │       ├── collections.yml
-│       ├── converge.yml
-│       ├── create.yml
-│       ├── destroy.yml
 │       ├── init.yml
 │       ├── molecule.yml
-│       ├── prepare.yml
-│       ├── requirements.yml
-│       └── verify.yml
+│       └── requirements.yml
 ├── handlers
 ├── LICENSE
 [...]
 ```
+
+## Update configuration
+
+The 'platform' configuration for the Molecule scenario can be updated in the `molecule/default/molecule.yml` file as needed.
+
+The 'converge' playbook can be updated in the `molecule/resources/converge.yml` file as needed.
+
 
 ## Run Molecule to verify initial setup
 
@@ -106,9 +121,8 @@ For example:
 init_platforms:
   - name: docker-rocklinux9
     type: docker
-    config:
-      image: "geerlingguy/docker-rockylinux9-ansible:latest"
-      systemd: true
+    image: "geerlingguy/docker-rockylinux9-ansible:latest"
+    systemd: true
 ```
 
 The name of each platform should be unique, and other Systemd-enabled OS containers can be found [here](https://hub.docker.com/search?q=geerlingguy%2Fdocker-).
@@ -121,7 +135,7 @@ Role Variables
 --------------
 
 ```yaml
-# The type of project that this Molecule configuration will be integrated into
+# The type of project that this Molecule configuration will be integrated into (role, collection, playbook, monolith)
 init_project_type: auto
 
 # The type of platform that this Molecule configuration will be testing on (docker, ec2)
@@ -129,32 +143,38 @@ init_project_type: auto
 init_platform_type: docker
 
 # Version of this collection that should be used by the Molecule test
-# - Set to "" to attempt to use the running version
-init_collection_version: ""
+# - Set to "current" to attempt to use the running version
+init_collection_version: latest
 
 # Source of the collection that this role is part of (galaxy, git)
 init_collection_source: git
 
-# Filesystem location of the molecule scenario being initialized
-init_scenario_dir: "{{ molecule_scenario_directory | default(playbook_dir) }}"
+# Path to the ansible secret file that should be used by the Molecule test
+#  - Variable substitution can be used as described here: https://ansible.readthedocs.io/projects/molecule/configuration/#variable-substitution
+#  - Set to "" to disable
+init_ansible_secret_path: "{{ lookup('env', 'ANSIBLE_VAULT_PASSWORD_FILE') | default('') }}"
 
-# The filesystem location of the project being tested by this Molecule configuration
-#  - default value assumes that your Molecule project is located at <project dir>/molecule/<scenario>
-init_project_dir: "{{ init_scenario_dir.split('/')[:-2] | join('/') }}"
-
-# Platforms that this test configuration should test
+# Platforms that this test configuration should run on
 #  list of dicts, each required to contain:
 #    name: (string)
 #    type: (string)
-#    config: (dictionary, configuration for specified "type")
+#    <platform-specific configuration>
 #
 #  for example, in the case of the "docker" type:
-#    config:
+#    - name: docker-platform-with-a-descriptive-name
+#      type: docker
 #      image: (string, container image path)
-#      systemd: (true/false)
-#      modify_image: (true/false)
-#      modify_image_buildpath: (string)     # path to directory containing Dockerfile
-#      privileged: (true/false)
+#      systemd: (true/false)                # enable systemd in the container
+#      privileged: (true/false)             # run the container in privileged mode
+#      cpus: (int)                          # number of CPUs to allocate to the container
+#      memory: (int)K/M/G                   # amount of memory to allocate to the container
+#      published_ports: (list)              # list of ports to publish from the container
+#      exec_systemd: (true/false)           # customize the container entrypoint to run systemd
+#      exec_systemd_build_commands: (list)  # commands to run when building the systemd-enabled container
+#      hostvars: (dict)                     # hostvars to be added to the Ansible inventory
+#
+#   See README.md in the 'roles/docker_platform' directory for more information
+#    - Similarly, other platform types will have their own README.md files
 #
 # If not specified, the role will attempt to use the default platform configuration
 init_platforms: []
@@ -162,17 +182,17 @@ init_platforms: []
 # Create backups of any files that would be clobbered by running this role
 init_file_backup: true
 
-# Path to the ansible secret file that should be used by the Molecule test
-#  - Variable substitution can be used as described here: https://ansible.readthedocs.io/projects/molecule/configuration/#variable-substitution
-#  - Set to "" to disable
-init_ansible_secret_path: ""
+# Overwrite any existing 'resource' playbook files in the 'molecule/resources' directory
+init_overwrite_resources: false
+
+# Initialize ARA support in the Molecule configuration -- https://ara.recordsansible.org/
+init_ara_support: true
 ```
 
 Dependencies
 ------------
 
 **Collections**  
-* community.docker
 * influxdata.molecule
 
 Example Playbook
@@ -193,10 +213,9 @@ Example Playbook
         init_platforms:
           - name: docker-amazonlinux2023
             type: docker
-            config:
-              image: geerlingguy/docker-amazonlinux2023-ansible:latest
-              systemd: true
-              privileged: false
+            image: geerlingguy/docker-amazonlinux2023-ansible:latest
+            systemd: true
+            privileged: false
 ```
 
 License

--- a/roles/init/defaults/main.yml
+++ b/roles/init/defaults/main.yml
@@ -20,19 +20,27 @@ init_collection_source: git
 #  - Set to "" to disable
 init_ansible_secret_path: "{{ lookup('env', 'ANSIBLE_VAULT_PASSWORD_FILE') | default('') }}"
 
-# Platforms that this test configuration should test
+# Platforms that this test configuration should run on
 #  list of dicts, each required to contain:
 #    name: (string)
 #    type: (string)
-#    config: (dictionary, configuration for specified "type")
+#    <platform-specific configuration>
 #
 #  for example, in the case of the "docker" type:
-#    config:
+#    - name: docker-platform-with-a-descriptive-name
+#      type: docker
 #      image: (string, container image path)
-#      systemd: (true/false)
-#      modify_image: (true/false)
-#      modify_image_buildpath: (string)     # path to directory containing Dockerfile
-#      privileged: (true/false)
+#      systemd: (true/false)                # enable systemd in the container
+#      privileged: (true/false)             # run the container in privileged mode
+#      cpus: (int)                          # number of CPUs to allocate to the container
+#      memory: (int)K/M/G                   # amount of memory to allocate to the container
+#      published_ports: (list)              # list of ports to publish from the container
+#      exec_systemd: (true/false)           # customize the container entrypoint to run systemd
+#      exec_systemd_build_commands: (list)  # commands to run when building the systemd-enabled container
+#      hostvars: (dict)                     # hostvars to be added to the Ansible inventory
+#
+#   See README.md in the 'roles/docker_platform' directory for more information
+#    - Similarly, other platform types will have their own README.md files
 #
 # If not specified, the role will attempt to use the default platform configuration
 init_platforms: []

--- a/roles/init/files/init.yml
+++ b/roles/init/files/init.yml
@@ -7,8 +7,6 @@
   gather_facts: false
   tasks:
     - name: Launch provisioner
-      ansible.builtin.include_role:
-        name: influxdata.molecule.init
       vars:
         # Supported platform types are: docker, ec2
         init_platform_type: docker
@@ -29,20 +27,36 @@
         # Overwrite any existing 'resource' playbook files in the 'molecule/resources' directory
         init_overwrite_resources: false
 
-        # Platforms that this test configuration should test
+        # Path to the ansible secret file that should be used by the Molecule test
+        #  - Variable substitution can be used as described here:
+        #    https://ansible.readthedocs.io/projects/molecule/configuration/#variable-substitution
+        #  - Set to "" to disable
+        init_ansible_secret_path: "{{ lookup('env', 'ANSIBLE_VAULT_PASSWORD_FILE') | default('') }}"
+
+        # Platforms that this test configuration should run on
         #  list of dicts, each required to contain:
         #    name: (string)
         #    type: (string)
-        #    config: (dictionary, configuration for specified "type")
+        #    <platform-specific configuration>
         #
         #  for example, in the case of the "docker" type:
-        #    config:
+        #    - name: docker-platform-with-a-descriptive-name
+        #      type: docker
         #      image: (string, container image path)
-        #      systemd: (true/false)
-        #      modify_image: (true/false)
-        #      modify_image_buildpath: (string)     # path to directory containing Dockerfile
-        #      privileged: (true/false)
+        #      systemd: (true/false)                # enable systemd in the container
+        #      privileged: (true/false)             # run the container in privileged mode
+        #      cpus: (int)                          # number of CPUs to allocate to the container
+        #      memory: (int)K/M/G                   # amount of memory to allocate to the container
+        #      published_ports: (list)              # list of ports to publish from the container
+        #      exec_systemd: (true/false)           # customize the container entrypoint to run systemd
+        #      exec_systemd_build_commands: (list)  # commands to run when building the systemd-enabled container
+        #      hostvars: (dict)                     # hostvars to be added to the Ansible inventory
+        #
+        #   See README.md in the 'roles/docker_platform' directory for more information
+        #    - Similarly, other platform types will have their own README.md files
         #
         # If not specified, the role will attempt to use the default platform configuration
         init_platforms: []
+      ansible.builtin.include_role:
+        name: influxdata.molecule.init
 

--- a/roles/init/meta/main.yml
+++ b/roles/init/meta/main.yml
@@ -31,8 +31,13 @@ galaxy_info:
   platforms:
     - name: Fedora
       versions:
-      - all
-      - 29
+        - 41
+    - name: Rocky
+      versions:
+        - 9
+    - name: Ubuntu
+      versions:
+        - 24.04
 
   galaxy_tags:
     - molecule

--- a/roles/init/tasks/asserts.yml
+++ b/roles/init/tasks/asserts.yml
@@ -87,6 +87,8 @@
       - __init_runtime_platforms | length > 0
     fail_msg: >
       Runtime platform configuration is not sane!
+      Only one platform type is supported per scenario.
+      Unique platform names are required.
       Platform configuration:
       {{ __init_runtime_platforms }}
     success_msg: Sanity check passed with platforms '{{ __init_runtime_platforms }}'

--- a/roles/init/templates/cleanup.yml.j2
+++ b/roles/init/templates/cleanup.yml.j2
@@ -1,7 +1,8 @@
 ---
 # The cleanup.yml playbook should be used to remove any test infrastructure that was created by this test process
 #  and is not present within the instance itself (IE: the docker container created by Molecule). For example, it
-#  could be used to remove AWS infrastructure created as part of this test and that should not persist.
+#  could be used to remove AWS infrastructure created as part of this test and that should not persist, but is not
+#  automatically managed by the {{ ansible_collection_name }} collection.
 
 - name: Remove external test infrastructure
   hosts: molecule

--- a/roles/init/templates/converge.yml.j2
+++ b/roles/init/templates/converge.yml.j2
@@ -16,7 +16,9 @@
         that: "'molecule' in groups"
         fail_msg: |
           molecule group was not found inside inventory groups: {{ groups }}
+{% endraw %}
 
+{% if init_project_type in ['role', 'collection', 'monolith'] %}
 - name: Converge
   hosts: molecule
   vars:
@@ -31,96 +33,46 @@
       ansible.builtin.assert:
         that: result.stdout | regex_search("^Linux")
 
-    - name: Do preparation
-      block:
-        - name: Load local host facts
-          ansible.builtin.setup:
-            gather_subset:
-              - '!all'
-              - '!min'
-              - local
-
-        - name: Show local Ansible facts
-          ansible.builtin.debug:
-            var: ansible_facts.ansible_local
-            verbosity: 1
-
-        - name: Test local fact exists
-          ansible.builtin.assert:
-            that:
-              - ansible_local.molecule.test_prepare_fact is defined
-            fail_msg: Something went wrong with storing local facts!
-            success_msg: Local fact exists
-
-    - name: Run the init role
+{% if init_project_type == 'role' %}
+    - name: Test role your_role_here
       vars:
-        test_dir: /tmp/molecule-init
-        test_init_wget_path: "https://raw.githubusercontent.com/influxdata/ansible-collection-molecule/main/roles/init/files/init.yml"
-        test_collection_dir: "{{ test_dir }}/ci_testing/test_collection"
-        test_role_dir: "{{ test_dir }}/ci_testing/test_collection"
-      block:
-        - name: Local work dir exists
-          ansible.builtin.file:
-            path: "{{ test_dir }}"
-            state: directory
+        ansible_user: molecule_runner
+      ansible.builtin.include_role:
+        name: your_role_here
+{% elif init_project_type == 'collection' %}
+    # Add tasks to test collection elements here
+    #  For example, to test a role in a collection:
+    - name: Test your_collection.role_here
+      vars:
+        ansible_user: molecule_runner
+      ansible.builtin.include_role:
+        name: your_collection.role_here
+{% elif init_project_type == 'monolith' %}
+    # Top level monolithic repository tests here!
+    # Tests of individual roles and playbooks should be done in their respective directories.
+    # Monolithic repository level test scopes should target processes that span multiple roles or playbooks.
+    - name: Test monolithic repository
+      ansible.builtin.debug:
+        msg: "Add your monolithic repository tests here!"
 
-        - name: Test with a collection
-          block:
-            - name: Test collection is created
-              ansible.builtin.command:
-                chdir: "{{ test_dir }}"
-                cmd: ansible-galaxy collection init ci_testing.test_collection
-                creates: "{{ test_collection_dir }}"
+    - name: Test role your_role_here
+      vars:
+        ansible_user: molecule_runner
+      ansible.builtin.include_role:
+        name: your_role_here
 
-            - name: Molecule scenario dir exists for collection
-              ansible.builtin.file:
-                path: "{{ test_collection_dir }}/molecule/default"
-                state: directory
-
-            - name: Molecule init playbook exists for collection
-              ansible.builtin.command:
-                chdir: "{{ test_collection_dir }}"
-                cmd: wget -P molecule/default {{ test_init_wget_path }}
-                creates: "{{ test_collection_dir }}/molecule/default/init.yml"
-
-            - name: Run init playbook on collection
-              # TODO: Actually check idempotence on this
-              ansible.builtin.command:
-                chdir: "{{ test_collection_dir }}"
-                cmd: ansible-playbook molecule/default/init.yml
-              changed_when: false
-
-        - name: Test with a role
-          block:
-            - name: Test role is created
-              ansible.builtin.command:
-                chdir: "{{ test_dir }}"
-                cmd: ansible-galaxy role init test_role
-                creates: "{{ test_role_dir }}"
-
-            - name: Molecule scenario dir exists for role
-              ansible.builtin.file:
-                path: "{{ test_role_dir }}/molecule/default"
-                state: directory
-
-            - name: Molecule init playbook exists for role
-              ansible.builtin.command:
-                chdir: "{{ test_role_dir }}"
-                cmd: wget -P molecule/default {{ test_init_wget_path }}
-                creates: "{{ test_role_dir }}/molecule/default/init.yml"
-
-            - name: Run init playbook on role
-              # TODO: Actually check idempotence on this
-              ansible.builtin.command:
-                chdir: "{{ test_role_dir }}"
-                cmd: ansible-playbook molecule/default/init.yml
-              changed_when: false
-
-        - name: Test with a monolith
-          block:
-            # TODO: Find/create a public monolith repo we can use to test this
-            - name: "TODO: Write monolith test"
-              ansible.builtin.debug:
-                msg: This test hasn't been written! You get a cookie if you can fix that! 🍪
-
+{% endif %}
+{% endif %}
+{% if init_project_type in ['playbook','monolith'] %}
+{%- raw -%}
+- name: Include playbook your_playbook_here
+  vars:
+    # Note: Your playbook must include this variable in its 'hosts' directive
+    #  IE: hosts: "{{ playbook_target_hosts | default('all') }}"
+    #
+    # WARNING: Take care not to run against 'localhost' as this is the runner, and not the target!
+    playbook_target_hosts: molecule
+  ansible.builtin.import_playbook: "{{ playbook_dir }}../../your_playbook_here.yml"
 {% endraw %}
+
+{% endif %}

--- a/roles/init/templates/create.yml.j2
+++ b/roles/init/templates/create.yml.j2
@@ -6,16 +6,10 @@
     - name: Create docker platform(s)
       ansible.builtin.include_role:
         name: {{ ansible_collection_name }}.platform
-      vars:{% raw %}
-        platform_name: "{{ item.name }}"
-        platform_state: present
-        platform_type: "{{ item.type }}"
-        platform_molecule_cfg: "{{ item }}"
-      loop: "{{ molecule_yml.platforms }}"
-      loop_control:
-        label: item.name
 
+{% raw %}
 # We want to avoid errors like "Failed to create temporary directory"
+#  so we connect to the container and verify that the system is ready.
 - name: Validate that inventory was refreshed
   hosts: molecule
   gather_facts: false
@@ -36,6 +30,7 @@
           - ansible_service_mgr
 
     - name: Check on Systemd
+      when: ansible_service_mgr == 'systemd'
       block:
         - name: Wait for systemd to complete initialization.
           ansible.builtin.command: systemctl is-system-running
@@ -47,12 +42,4 @@
           delay: 5
           changed_when: false
           failed_when: systemctl_status.rc > 1
-
-        - name: Check systemd status
-          ansible.builtin.assert:
-            that:
-              - systemctl_status.stdout == 'running'
-            fail_msg: Systemd-enabled host does not have a healthy Systemd!
-            success_msg: Systemd is running
-      when: ansible_service_mgr == 'systemd'
 

--- a/roles/init/templates/destroy.yml.j2
+++ b/roles/init/templates/destroy.yml.j2
@@ -5,16 +5,8 @@
   gather_facts: false
   tasks:
     - name: Remove platform
+      vars:
+        platform_state: absent
       ansible.builtin.include_role:
         name: {{ ansible_collection_name }}.platform
-      vars:
-{%- raw %}
-        platform_name: "{{ item.name }}"
-        platform_state: absent
-        platform_type: "{{ item.type }}"
-        platform_molecule_cfg: "{{ item }}"
-      loop: "{{ molecule_yml.platforms }}"
-      loop_control:
-        label: item.name
-{%- endraw %}
 

--- a/roles/init/templates/molecule.yml.j2
+++ b/roles/init/templates/molecule.yml.j2
@@ -7,19 +7,30 @@ driver:
   options:
     managed: true
 {% if 'docker' in init_platforms | map(attribute='type') %}
+{% if init_platforms | map(attribute='type') | list | unique | count > 1 %}
+    # WARNING! Multiple platform types are defined! This is not supported!
+    #   - 'molecule login' will only work for docker containers
+    #   - random, unexpected behavior may occur
+    #   - the sky may fall
+{% endif %}
     login_cmd_template: 'docker exec -ti {instance} bash --login'
 {% endif %}
 platforms:
   # See platform documentation at {{ __init_collection_repository }}/tree/main/roles/{{ init_platform_type }}_platform/README.md
 {% for init_platform in __init_runtime_platforms %}
-  - name: {{ init_platform.name | default('docker-platform') }}
+  - name: {{ init_platform.name }}
     type: {{ init_platform.type }}
-{% for key, value in init_platform.items() -%}
+{% for key, value in init_platform.items() %}
 {% if key not in ['name', 'type', 'hostvars'] %}
     {{ key }}: {{ value }}
 {% endif %}
-{%- endfor %}
-    hostvars: {{ init_platform.hostvars | default({}) }}
+{% endfor -%}
+{%- if init_platform.hostvars is defined and init_platform.hostvars is truthy %}
+    hostvars:
+      {{ init_platform.hostvars | to_nice_yaml }}
+{%- else %}
+    hostvars: {}
+{% endif %}
 {% endfor %}
 provisioner:
   name: ansible

--- a/roles/init/templates/platform_cfg/docker.yml.j2
+++ b/roles/init/templates/platform_cfg/docker.yml.j2
@@ -1,9 +1,0 @@
-- name: {{ init_platform.name | default('docker-platform') }}
-  type: {{ init_platform.type }}
-  # See platform documentation at {{ __init_collection_repository }}/tree/main/roles/{{ init_platform.type }}_platform/README.md
-  {% for key, value in init_platform.items() %}
-  {% if key not in ['name', 'type', 'hostvars'] %}
-  {{ key }}: {{ value }}
-  {% endif %}
-  {% endfor %}
-  hostvars: {{ init_platform.hostvars | default({}) }}

--- a/roles/init/templates/prepare.yml.j2
+++ b/roles/init/templates/prepare.yml.j2
@@ -5,10 +5,10 @@
   tags: always
   tasks:
     - name: Configure for standalone role testing
-      ansible.builtin.include_role:
-        name: influxdata.molecule.prepare_controller
       vars:
         prepare_controller_project_type: {{ init_project_type }}
+      ansible.builtin.include_role:
+        name: influxdata.molecule.prepare_controller
 
 - name: Prepare target host for execution
   hosts: molecule

--- a/roles/init/vars/main.yml
+++ b/roles/init/vars/main.yml
@@ -20,7 +20,7 @@ __init_supported_platform_types:
 __init_runtime_platforms: >-
    {%- set __init_platforms = [] -%}
    {%- for __init_platform in init_platforms -%}
-      {%- set _ = __init_platforms.append(__init_platform | combine(init_platform_defaults)) -%}
+      {%- set _ = __init_platforms.append(init_platform_defaults | combine(__init_platform, recursive=True)) -%}
    {%- endfor -%}
    {%- if __init_platforms | length == 0 -%}
       {%- set __init_platforms = [init_platform_defaults] -%}


### PR DESCRIPTION
Fix templates included with the 'init' role to deploy in a runnable format

Update docs

Only deploy to Ansible Galaxy if a Galaxy API token is provided via repository secrets