### PR TITLE
fix: add retry logic to ephemeral security group deletion

### DIFF
--- a/roles/ec2_platform/tasks/absent.yml
+++ b/roles/ec2_platform/tasks/absent.yml
@@ -112,6 +112,10 @@
     vpc_id: "{{ __ec2_platform.vpc_id or __ec2_platform_subnet_info.subnets[0] }}"
     name: "{{ __ec2_platform.security_group_name }}"
     state: absent
+  register: __ec2_sg_destroy_result
+  retries: 10
+  delay: 5
+  until: __ec2_sg_destroy_result is success
 
 - name: EC2 Deprovision | Destroy ephemeral keys (if needed)
   loop: "{{ ec2_platforms | selectattr('key_inject_method', 'equalto', 'ec2') }}"


### PR DESCRIPTION
## Summary
- Add `retries: 10 / delay: 5 / until: success` to the SG deletion task in `ec2_platform/tasks/absent.yml`
- Matches the existing retry pattern used for instance destruction in the same file
- Fixes intermittent `DependencyViolation` errors when AWS ENIs haven't fully detached after instance termination

## Context
The `role-etcd-docker-ec2` molecule scenario in `influxdata/cloud1-awx` (PR #2295) fails during the destroy phase because the security group deletion has no retry logic. Instance destruction uses async + 60 retries x 5s, but SG deletion immediately follows with zero retries. The `DependencyViolation` error is a known AWS eventual consistency issue.

## Test plan
- [x] Re-run `role-etcd-docker-ec2` scenario in cloud1-awx after this merges to verify destroy phase completes cleanly
- [x] Verify no regression in other EC2-based molecule scenarios