### PR TITLE
fix(ec2_platform): read EBS block devices from ebs_volumes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,11 @@ on:
   pull_request:
     branches:
       - main
+      - devel
+  # Molecule is tracked unpinned; a weekly run surfaces breaking upstream releases
+  # here rather than in a consumer's unrelated pull request.
+  schedule:
+    - cron: '0 6 * * 1'
   workflow_dispatch:
     inputs:
       runner-type:

--- a/molecule/ec2_platform/molecule.yml
+++ b/molecule/ec2_platform/molecule.yml
@@ -17,7 +17,6 @@ platforms:
     ssh_user: molecule_runner
     ebs_volumes:
       - device_name: /dev/xvdb
-        virtual_name: molecule-ec2-platform-disk1
         ebs:
           volume_type: gp3
           volume_size: 2

--- a/molecule/ec2_platform/molecule.yml
+++ b/molecule/ec2_platform/molecule.yml
@@ -15,6 +15,13 @@ platforms:
     vpc_subnet_id: subnet-0725b4ef4d069f1bf
     instance_type: t3.small
     ssh_user: molecule_runner
+    ebs_volumes:
+      - device_name: /dev/xvdb
+        virtual_name: molecule-ec2-platform-disk1
+        ebs:
+          volume_type: gp3
+          volume_size: 2
+          delete_on_termination: true
     hostvars:
       test_hostvar: test
   - name: ec2-unbuntu2204

--- a/molecule/resources/verify.yml
+++ b/molecule/resources/verify.yml
@@ -26,6 +26,8 @@
             __ebs_expected_size: "{{ 2 * 1024 * 1024 * 1024 }}"
           ansible.builtin.assert:
             that:
-              - __ebs_expected_size in (__ebs_block_devices.stdout_lines | map('trim') | list)
-            fail_msg: "Declared ebs_volumes disk not attached! EBS block device mapping is not reaching the instance."
+              - __ebs_expected_size | int in (__ebs_block_devices.stdout_lines | map('int') | list)
+            fail_msg: >-
+              Declared ebs_volumes disk not attached! Expected a device of
+              {{ __ebs_expected_size }} bytes, saw {{ __ebs_block_devices.stdout_lines }}.
             success_msg: "Declared ebs_volumes disk found!"

--- a/molecule/resources/verify.yml
+++ b/molecule/resources/verify.yml
@@ -11,3 +11,21 @@
         fail_msg: "Custom hostvar not found! Possible issue with storing user-defined hostvars!"
         success_msg: "Custom hostvar found!"
 
+    # Guarded by host: this playbook is shared with the docker `default` scenario,
+    # which attaches no EBS volumes.
+    - name: Test ebs_volumes disk is attached
+      when: inventory_hostname == 'ec2-rockylinux9'
+      block:
+        - name: Read attached block devices
+          ansible.builtin.command: lsblk --bytes --nodeps --noheadings --output SIZE
+          register: __ebs_block_devices
+          changed_when: false
+
+        - name: Test the declared volume is present
+          vars:
+            __ebs_expected_size: "{{ 2 * 1024 * 1024 * 1024 }}"
+          ansible.builtin.assert:
+            that:
+              - __ebs_expected_size in (__ebs_block_devices.stdout_lines | map('trim') | list)
+            fail_msg: "Declared ebs_volumes disk not attached! EBS block device mapping is not reaching the instance."
+            success_msg: "Declared ebs_volumes disk found!"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@
 ansible-core==2.20.1
 ansible-lint
 requests>=2.32.3
-molecule==25.12.0
+molecule>=25.12.0
 boto3[crt]
 

--- a/roles/ec2_platform/README.md
+++ b/roles/ec2_platform/README.md
@@ -37,7 +37,9 @@ Optional configuration options are:
 - `image_owner`: The owner of the image to use for the instance (string)
 - `security_groups`: A list of security group names to apply to the instance (list of strings)
 - `tags`: A dictionary of tags to apply to the instance (dictionary)
-- `volumes`: A list of volumes to attach to the instance (list of dicts)
+- `ebs_volumes`: A list of EBS block device mappings to attach to the instance (list of dicts)
+- `volumes`: Deprecated alias for `ebs_volumes`. Molecule >= 26.8.0 validates `platforms[].volumes`
+  as a list of strings (Docker bind mounts), so new configuration should use `ebs_volumes`.
 
 Requirements
 ------------

--- a/roles/ec2_platform/defaults/main.yml
+++ b/roles/ec2_platform/defaults/main.yml
@@ -11,10 +11,16 @@ ec2_platform_state: "{{ platform_target_state | default('present') }}"
 ec2_platform_definition: "{{ [platform_target_config] if platform_target_config is defined else (molecule_yml.platforms | default([])) }}"
 
 # Merge the defaults with any options provided to this role
+#
+# `volumes` is a deprecated alias for `ebs_volumes`, coalesced here so consumers
+# read one key. Molecule >= 26.8.0 validates platforms[].volumes as a list of
+# strings (Docker bind mounts), so EBS block device mappings need a key that
+# Molecule does not define.
 ec2_platforms: >-
   {%- set __platforms = [] -%}
   {%- for __platform in ec2_platform_definition -%}
     {%- set __platform = ec2_platform_defaults | combine(__platform) -%}
+    {%- set _ = __platform.update({'ebs_volumes': __platform.ebs_volumes or __platform.volumes}) -%}
     {%- set _ = __platforms.append(__platform) -%}
   {%- endfor -%}
   {{ __platforms }}
@@ -76,6 +82,7 @@ ec2_platform_defaults:
   ssh_user: "{{ ec2_platform_default_ssh_user }}"
   ssh_port: "{{ ec2_platform_default_ssh_port }}"
   cloud_config: {}
+  ebs_volumes: []
   image: ""
   image_name: ""
   image_owner: [self]

--- a/roles/ec2_platform/tasks/present.yml
+++ b/roles/ec2_platform/tasks/present.yml
@@ -141,7 +141,7 @@
     security_groups: "{{ __ec2_platform_security_groups }}"
     network:
       assign_public_ip: "{{ __ec2_platform.assign_public_ip }}"
-    volumes: "{{ __ec2_platform.volumes }}"
+    volumes: "{{ __ec2_platform.ebs_volumes }}"
     key_name: "{{ (__ec2_platform.key_inject_method == 'ec2') | ternary(__ec2_platform.key_name, omit) }}"
     tags: "{{ __ec2_platform_tags }}"
     user_data: "{{ __ec2_platform_user_data }}"

--- a/roles/ec2_platform/tasks/validate_cfg.yml
+++ b/roles/ec2_platform/tasks/validate_cfg.yml
@@ -35,7 +35,7 @@
       - __ec2_platform_item.ssh_user is string and __ec2_platform_item.ssh_user | length > 0
       - __ec2_platform_item.ssh_port is integer and __ec2_platform_item.ssh_port in range(1, 65536)
       - __ec2_platform_item.tags is mapping
-      - __ec2_platform_item.volumes is sequence
+      - __ec2_platform_item.ebs_volumes is sequence
       - __ec2_platform_item.vpc_id is string
       - __ec2_platform_item.vpc_subnet_id is string and __ec2_platform_item.vpc_subnet_id | length > 0
     fail_msg: "Invalid EC2 platform configuration provided!"


### PR DESCRIPTION
## Summary

- Molecule 26.8.0 re-attached `MoleculePlatformModel` to `platforms[]` ([ansible/molecule#4661](https://github.com/ansible/molecule/pull/4661)), which types `volumes` as an array of **strings** — Docker bind-mount syntax. EC2 block-device mappings (list of dicts) stopped validating, failing scenarios before any action runs.
- `ebs_volumes` becomes the supported key for EBS block device mappings. `volumes` is coalesced as a deprecated alias, so existing consumer configuration keeps working unchanged.
- The `ec2_platform` scenario declared no volumes at all, so this code path was never exercised in CI. It now attaches a disk and asserts it.
- Molecule moves from `==25.12.0` to `>=25.12.0`. Pinning exactly meant this repo certified a version no consumer runs, which is why a downstream repo hit this first.

## Changes

### roles/ec2_platform
- `ec2_platforms` coalesces `volumes` into `ebs_volumes`, so consumers read one key
- `present.yml` and `validate_cfg.yml` read `ebs_volumes`
- `ebs_volumes: []` added to `ec2_platform_defaults`; README documents both keys

### CI and test coverage
- `molecule/ec2_platform`: the rockylinux9 platform declares a 2 GiB gp3 volume
- `molecule/resources/verify.yml`: asserts the volume is attached — host-guarded, since this playbook is shared with the docker `default` scenario
- `requirements.txt`: `molecule>=25.12.0`
- `build.yml`: weekly schedule, and pull requests into `devel` — which previously triggered no CI, since the trigger only listed `main`

## Testing

`molecule test -s ec2_platform` passes on this branch (run 32420167949). The new verify task confirms the declared volume reaches the guest — `lsblk` reports the root device plus the 2 GiB volume, and the assertion is `Declared ebs_volumes disk found!`. `molecule test -s default` also passes; its assertion is host-guarded and skips there.

The deprecated `volumes` alias cannot be covered by CI here: molecule >= 26.8.0 rejects a dict-valued `volumes` at schema validation before the role runs, so the alias is only reachable on <= 26.6.0. It was validated manually instead — a downstream EC2 scenario pinned to this collection's `devel` tag, running molecule 26.4.0 with the old key, attached all three declared disks (2G GPT, 5G LVM, 2G msdos) and completed prepare with `failed=0`.

Also verified offline:
- The `ec2_platforms` expression was rendered directly from `defaults/main.yml` against four inputs — `ebs_volumes` only, `volumes` only, neither, and both — resolving correctly in each case, with `ebs_volumes` taking precedence.
- Both scenario files validate against Molecule 26.8.0's `MoleculePlatformModel`.

Note the deliberate tradeoff: with molecule unpinned, an upstream release can now redden this repo's CI on a change that did not cause it. That is the intended early warning, not a regression.

## Downstream

The only known consumers of the dict-valued `volumes` key are two EC2 scenarios in a downstream repository, which move to `ebs_volumes` separately. They stay broken until this merges **and ships in a release** — consumers pin `version: latest`, a moving tag that `publish.yml` advances only on a GitHub release.

---

*_PR drafted by the GLaDOS Facility Management System. Contents reviewed and approved by a human operator._*
