### PR TITLE
feat(ec2_platform): ebs_volumes for EBS mappings, ec2_private_ip hostvar

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,11 @@ on:
   pull_request:
     branches:
       - main
+      - devel
+  # Molecule is tracked unpinned; a weekly run surfaces breaking upstream releases
+  # here rather than in a consumer's unrelated pull request.
+  schedule:
+    - cron: '0 6 * * 1'
   workflow_dispatch:
     inputs:
       runner-type:

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: influxdata
 name: molecule
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 2.1.0
+version: 2.2.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/molecule/ec2_platform/molecule.yml
+++ b/molecule/ec2_platform/molecule.yml
@@ -15,6 +15,12 @@ platforms:
     vpc_subnet_id: subnet-0725b4ef4d069f1bf
     instance_type: t3.small
     ssh_user: molecule_runner
+    ebs_volumes:
+      - device_name: /dev/xvdb
+        ebs:
+          volume_type: gp3
+          volume_size: 2
+          delete_on_termination: true
     hostvars:
       test_hostvar: test
   - name: ec2-unbuntu2204

--- a/molecule/resources/verify.yml
+++ b/molecule/resources/verify.yml
@@ -11,3 +11,23 @@
         fail_msg: "Custom hostvar not found! Possible issue with storing user-defined hostvars!"
         success_msg: "Custom hostvar found!"
 
+    # Guarded by host: this playbook is shared with the docker `default` scenario,
+    # which attaches no EBS volumes.
+    - name: Test ebs_volumes disk is attached
+      when: inventory_hostname == 'ec2-rockylinux9'
+      block:
+        - name: Read attached block devices
+          ansible.builtin.command: lsblk --bytes --nodeps --noheadings --output SIZE
+          register: __ebs_block_devices
+          changed_when: false
+
+        - name: Test the declared volume is present
+          vars:
+            __ebs_expected_size: "{{ 2 * 1024 * 1024 * 1024 }}"
+          ansible.builtin.assert:
+            that:
+              - __ebs_expected_size | int in (__ebs_block_devices.stdout_lines | map('int') | list)
+            fail_msg: >-
+              Declared ebs_volumes disk not attached! Expected a device of
+              {{ __ebs_expected_size }} bytes, saw {{ __ebs_block_devices.stdout_lines }}.
+            success_msg: "Declared ebs_volumes disk found!"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@
 ansible-core==2.20.1
 ansible-lint
 requests>=2.32.3
-molecule==25.12.0
+molecule>=25.12.0
 boto3[crt]
 

--- a/roles/ec2_platform/README.md
+++ b/roles/ec2_platform/README.md
@@ -37,7 +37,9 @@ Optional configuration options are:
 - `image_owner`: The owner of the image to use for the instance (string)
 - `security_groups`: A list of security group names to apply to the instance (list of strings)
 - `tags`: A dictionary of tags to apply to the instance (dictionary)
-- `volumes`: A list of volumes to attach to the instance (list of dicts)
+- `ebs_volumes`: A list of EBS block device mappings to attach to the instance (list of dicts)
+- `volumes`: Deprecated alias for `ebs_volumes`. Molecule >= 26.8.0 validates `platforms[].volumes`
+  as a list of strings (Docker bind mounts), so new configuration should use `ebs_volumes`.
 
 Requirements
 ------------

--- a/roles/ec2_platform/defaults/main.yml
+++ b/roles/ec2_platform/defaults/main.yml
@@ -11,10 +11,16 @@ ec2_platform_state: "{{ platform_target_state | default('present') }}"
 ec2_platform_definition: "{{ [platform_target_config] if platform_target_config is defined else (molecule_yml.platforms | default([])) }}"
 
 # Merge the defaults with any options provided to this role
+#
+# `volumes` is a deprecated alias for `ebs_volumes`, coalesced here so consumers
+# read one key. Molecule >= 26.8.0 validates platforms[].volumes as a list of
+# strings (Docker bind mounts), so EBS block device mappings need a key that
+# Molecule does not define.
 ec2_platforms: >-
   {%- set __platforms = [] -%}
   {%- for __platform in ec2_platform_definition -%}
     {%- set __platform = ec2_platform_defaults | combine(__platform) -%}
+    {%- set _ = __platform.update({'ebs_volumes': __platform.ebs_volumes or __platform.volumes}) -%}
     {%- set _ = __platforms.append(__platform) -%}
   {%- endfor -%}
   {{ __platforms }}
@@ -76,6 +82,7 @@ ec2_platform_defaults:
   ssh_user: "{{ ec2_platform_default_ssh_user }}"
   ssh_port: "{{ ec2_platform_default_ssh_port }}"
   cloud_config: {}
+  ebs_volumes: []
   image: ""
   image_name: ""
   image_owner: [self]

--- a/roles/ec2_platform/tasks/main.yml
+++ b/roles/ec2_platform/tasks/main.yml
@@ -40,6 +40,7 @@
               'ansible_user': __platform_instance_config.user,
               'ansible_ssh_private_key_file': __platform_instance_config.identity_file,
               'ec2_instance_id': __platform_instance_config.instance_id,
+              'ec2_private_ip': __platform_instance_config.ec2_private_ip,
             } -%}
           {%- endif -%}
         {%- set _ = __platform_instances.update({

--- a/roles/ec2_platform/tasks/present.yml
+++ b/roles/ec2_platform/tasks/present.yml
@@ -141,7 +141,7 @@
     security_groups: "{{ __ec2_platform_security_groups }}"
     network:
       assign_public_ip: "{{ __ec2_platform.assign_public_ip }}"
-    volumes: "{{ __ec2_platform.volumes }}"
+    volumes: "{{ __ec2_platform.ebs_volumes }}"
     key_name: "{{ (__ec2_platform.key_inject_method == 'ec2') | ternary(__ec2_platform.key_name, omit) }}"
     tags: "{{ __ec2_platform_tags }}"
     user_data: "{{ __ec2_platform_user_data }}"

--- a/roles/ec2_platform/tasks/present.yml
+++ b/roles/ec2_platform/tasks/present.yml
@@ -191,6 +191,7 @@
       instance: "{{ __ec2_platform_instance_definition.name }}"
       address: "{{ __ec2_platform_instance_definition.assign_public_ip
         | ternary(__ec2_platform_instance_data.public_ip_address, __ec2_platform_instance_data.private_ip_address) }}"
+      ec2_private_ip: "{{ __ec2_platform_instance_data.private_ip_address }}"
       user: "{{ __ec2_platform_instance_definition.ssh_user }}"
       port: "{{ __ec2_platform_instance_definition.ssh_port }}"
       identity_file: "{{ __ec2_platform_instance_definition.private_key_path }}"

--- a/roles/ec2_platform/tasks/validate_cfg.yml
+++ b/roles/ec2_platform/tasks/validate_cfg.yml
@@ -35,7 +35,7 @@
       - __ec2_platform_item.ssh_user is string and __ec2_platform_item.ssh_user | length > 0
       - __ec2_platform_item.ssh_port is integer and __ec2_platform_item.ssh_port in range(1, 65536)
       - __ec2_platform_item.tags is mapping
-      - __ec2_platform_item.volumes is sequence
+      - __ec2_platform_item.ebs_volumes is sequence
       - __ec2_platform_item.vpc_id is string
       - __ec2_platform_item.vpc_subnet_id is string and __ec2_platform_item.vpc_subnet_id | length > 0
     fail_msg: "Invalid EC2 platform configuration provided!"


### PR DESCRIPTION
## Summary

Release of `devel` into `main` for **v2.2.0**. Two `ec2_platform` changes plus the version bump.

- **`ebs_volumes` replaces `volumes` for EBS block device mappings** (#24). Molecule 26.8.0 re-attached `MoleculePlatformModel` to `platforms[]` ([ansible/molecule#4661](https://github.com/ansible/molecule/pull/4661)), which types `volumes` as an array of **strings** — Docker bind-mount syntax. EC2 block-device dicts stopped passing schema validation, failing scenarios before any action ran. `volumes` is retained as a deprecated alias.
- **`ec2_private_ip` is exported as an inventory hostvar**, so consumers can map it to `ansible_backnet_host` or similar for workloads needing private-IP connectivity (etcd probing).
- CI hardening that arrived with #24: molecule tracks `>=25.12.0` instead of an exact pin, a weekly scheduled build, and pull requests into `devel` now run CI at all — the trigger previously listed only `main`.

## Changes

### roles/ec2_platform
- `ec2_platforms` coalesces `volumes` into `ebs_volumes` so consumers read one key; `present.yml` and `validate_cfg.yml` consume it
- `ebs_volumes: []` added to `ec2_platform_defaults`; README documents both keys
- `ec2_private_ip` added to the instance config and surfaced in the generated inventory hostvars

### CI
- `requirements.txt`: `molecule>=25.12.0`
- `build.yml`: weekly `schedule`, and `pull_request` extended to `devel`

## Testing

`molecule test -s ec2_platform` and `-s default` both pass on `devel` at `cbcadb78`. The ec2_platform scenario now declares an `ebs_volumes` disk and verify asserts it reaches the guest — previously it declared no volumes at all, which is why the regression reached consumers uncaught.

The deprecated `volumes` alias cannot be covered by CI: molecule >= 26.8.0 rejects a dict-valued `volumes` before the role runs, so that path is only reachable on <= 26.6.0. It was validated manually — a downstream EC2 scenario pinned to this branch, on molecule 26.4.0 with the old key, attached all three declared disks (2G GPT, 5G LVM, 2G msdos) and completed prepare with `failed=0`.

## Releasing

> [!IMPORTANT]
> Merging this is not enough. Consumers pin `version: latest`, which `publish.yml` moves only on a published GitHub **release**. `latest` currently points at `16d5a67` — **v2.0.1, 2025-03-07** — so PRs #20, #21, #23 and #24 have never reached them. Cut the v2.2.0 release after merge.

A downstream consumer is currently green against this branch, but only because it is temporarily pinned to the `devel` tag; it reverts to `latest` once v2.2.0 is released.

Two defects noticed while tracing the release path, neither addressed here:

- `publish.yml` gates on `github.event.release.prerelase` — misspelled. The unknown property is `null`, and GitHub coerces both `null` and `false` to `0`, so the condition is always true and prereleases publish too.
- The `ec2_platform` scenario intermittently loses SSH to the rockylinux9 host during `Install packages (RHEL Family)` (~50% of runs today). Because `deploy` is `needs: build`, this blocks the branch tag from moving.

---

*_PR drafted by the GLaDOS Facility Management System. Contents reviewed and approved by a human operator._*
