### PR TITLE
ci: tag the release version on a bump, refresh actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,10 +43,10 @@ jobs:
           - ec2_platform
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -64,7 +64,7 @@ jobs:
 
       - name: Log into AWS
         if: ${{ matrix.molecule-scenario == 'ec2_platform' }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -90,7 +90,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Create and Push Tag
         env:
@@ -107,3 +107,22 @@ jobs:
           # Push the tag to the repository
           git push origin "refs/tags/$TAG_NAME" --force
 
+      - name: Tag the release version
+        if: github.ref_name == 'main'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          TAG="v$(sed -n 's/^version:[[:space:]]*//p' galaxy.yml | head -1)"
+          # Version tags are immutable, and this runs on every push to main, so an
+          # unchanged version must be a no-op rather than a failure or a move.
+          # checkout does not fetch tags, so existence is checked against the remote.
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "$TAG already exists, nothing to do"
+            exit 0
+          fi
+          echo "Creating tag $TAG"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "refs/tags/$TAG"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: write
     if: |
-      github.event.release.prerelase == false
+      github.event.release.prerelease == false
     steps:
       - name: Check deployment configuration
         shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,9 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    # Overrides the workflow-level `contents: read`; tagging the release needs write.
+    permissions:
+      contents: write
     if: |
       github.event.release.prerelase == false
     steps:
@@ -27,11 +30,11 @@ jobs:
 
       - name: Checkout repository
         if: ${{ env.GALAXY_DEPLOYMENT_ENABLED == '0' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Tag latest release
         if: ${{ env.GALAXY_DEPLOYMENT_ENABLED == '0' }}
-        uses: EndBug/latest-tag@latest
+        uses: EndBug/latest-tag@v1
         with:
           ref: latest
           description: This tag is automatically generated on new releases.
@@ -39,7 +42,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and Deploy Collection
-        uses: artis3n/ansible_galaxy_collection@v2
+        uses: artis3n/ansible_galaxy_collection@v3
         if: ${{ env.GALAXY_DEPLOYMENT_ENABLED == '0' }}
         with:
           api_key: '${{ secrets.GALAXY_API_KEY }}'


### PR DESCRIPTION
## Summary

Version tags are created by hand in the release UI today, so minting a release means retyping a number that already lives in `galaxy.yml` — and `galaxy.yml` is currently at 2.2.0 with no matching tag to select.

- A push to `main` now creates `v<version>` from `galaxy.yml` when that tag does not already exist, so the release UI offers it in the dropdown instead of accepting free text.
- Every action is refreshed; all five were behind, and one was floating.
- The publish job gets `contents: write`, which it needs and did not have, and its prerelease gate is corrected.

## Changes

### Version tagging (`build.yml`)

Added to the existing `deploy` job, which already runs on push and holds `contents: write`:

- Gated to `main`, so a bump merged elsewhere does not mint a release tag early.
- Existence is checked against the remote with `git ls-remote`, because `checkout` does not fetch tags — a local `git tag -l` would always look empty.
- No-op when the version is unchanged, since this runs on *every* push to `main`, not only bumps. Version tags are immutable, so the step must never move one; it exits 0 and does nothing.

The pre-existing `Create and Push Tag` step is untouched and still force-pushes the branch-name tag (`main`, `devel`).

### Action versions

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/setup-python` | v5 | v7 |
| `aws-actions/configure-aws-credentials` | v4 | v6 |
| `artis3n/ansible_galaxy_collection` | v2 | v3 |
| `EndBug/latest-tag` | **`@latest`** | v1 |

`EndBug/latest-tag` was pinned to a floating `latest` tag, meaning a third-party action could change under the release path without notice. Now pinned to a major like everything else.

Both major bumps were checked against how this repo actually calls them:

- `configure-aws-credentials` v5 changed invalid-boolean input handling and v6 moved to node24; this workflow passes only `aws-access-key-id`, `aws-secret-access-key` and `aws-region`, so neither applies.
- `ansible_galaxy_collection` v3 removes only the long-deprecated `galaxy_config_file` input; this workflow passes `api_key` alone.

`checkout` v7 keeps `fetch-depth: 1` and `fetch-tags: false`, so the existing bare `git tag` in the deploy job stays safe.

### Prerelease gate

The job gated on `github.event.release.prerelase` — misspelled. The unknown property evaluates to `null`, and GitHub coerces both `null` and `false` to `0`, so the condition was always true: prereleases published to Galaxy and moved the `latest` tag alongside real releases. Now spelled `prerelease`, so it does what it reads as.

Behaviour change worth noting: prereleases will now be skipped by this job. That is the stated intent of the condition, but it is a change — this repository has shipped prereleases before (`v1.3.1-devel`).

### Publish permissions

`publish.yml` declares `permissions: contents: read` at workflow level, and its `deploy` job did not override it — but that job pushes the `latest` tag via `EndBug/latest-tag`, which needs write. The job now sets `contents: write` explicitly.

## Testing

No molecule scenario covers workflow configuration. Both files parse as YAML, and the version-tag step's own logic is guarded so the first run on an already-tagged version is a no-op.

The step is unverified end to end until a bump lands on `main` — the next release is its first real exercise. Worth watching that run.

---

*_PR drafted by the GLaDOS Facility Management System. Contents reviewed and approved by a human operator._*
