### PR TITLE
fix(ci): move the latest tag whether or not Galaxy is enabled

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
   release:
     types:
       - published
-  # Re-point `latest` without cutting a release.
+  # Re-point `latest` at the newest release without cutting a new one.
   workflow_dispatch:
 permissions:
   contents: read
@@ -32,8 +32,33 @@ jobs:
             echo "GALAXY_DEPLOYMENT_ENABLED=true" >> $GITHUB_ENV
           fi
 
+      # `latest` means the newest released version. The branch heads already have
+      # their own `main`/`devel` tags, so resolve a release tag rather than
+      # tagging whatever ref triggered this run.
+      - name: Resolve the release to tag
+        id: release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.release.tag_name }}"
+          if [ -z "$TAG" ]; then
+            # workflow_dispatch: `gh release view` reports the newest release,
+            # excluding drafts and prereleases.
+            TAG="$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)"
+          fi
+          if [ -z "$TAG" ]; then
+            echo "::error::No release found to tag as latest."
+            exit 1
+          fi
+          echo "Tagging $TAG as latest"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          ref: ${{ steps.release.outputs.tag }}
 
       # Pushing to Galaxy is optional; tagging must not be gated on the API key.
       - name: Tag latest release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,8 @@ on:
   release:
     types:
       - published
+  # Re-point `latest` without cutting a release.
+  workflow_dispatch:
 permissions:
   contents: read
 
@@ -14,6 +16,8 @@ jobs:
     # Overrides the workflow-level `contents: read`; tagging the release needs write.
     permissions:
       contents: write
+    # A prerelease must not move `latest`. On workflow_dispatch the property is
+    # undefined, and Actions coerces both null and false to 0, so this still runs.
     if: |
       github.event.release.prerelease == false
     steps:
@@ -21,19 +25,18 @@ jobs:
         shell: bash
         run: |
           if [ -z "${{ secrets.GALAXY_API_KEY }}" ]; then
-            echo "No Galaxy API key found. Skipping deployment."
-            echo "GALAXY_DEPLOYMENT_ENABLED=1" >> $GITHUB_ENV
+            echo "No Galaxy API key found. Skipping Galaxy deployment."
+            echo "GALAXY_DEPLOYMENT_ENABLED=false" >> $GITHUB_ENV
           else
-            echo "Galaxy API key found. Deploying collection."
-            echo "GALAXY_DEPLOYMENT_ENABLED=0" >> $GITHUB_ENV
+            echo "Galaxy API key found. Deploying collection to Galaxy."
+            echo "GALAXY_DEPLOYMENT_ENABLED=true" >> $GITHUB_ENV
           fi
 
       - name: Checkout repository
-        if: ${{ env.GALAXY_DEPLOYMENT_ENABLED == '0' }}
         uses: actions/checkout@v7
 
+      # Pushing to Galaxy is optional; tagging must not be gated on the API key.
       - name: Tag latest release
-        if: ${{ env.GALAXY_DEPLOYMENT_ENABLED == '0' }}
         uses: EndBug/latest-tag@v1
         with:
           ref: latest
@@ -43,7 +46,7 @@ jobs:
 
       - name: Build and Deploy Collection
         uses: artis3n/ansible_galaxy_collection@v3
-        if: ${{ env.GALAXY_DEPLOYMENT_ENABLED == '0' }}
+        if: ${{ env.GALAXY_DEPLOYMENT_ENABLED == 'true' }}
         with:
           api_key: '${{ secrets.GALAXY_API_KEY }}'
 

--- a/README.md
+++ b/README.md
@@ -184,12 +184,22 @@ roles_path = ./roles:/usr/share/ansible/roles:/etc/ansible/roles:~/.ansible/role
 collections_path = ./collections:/usr/share/ansible/collections:~/.ansible/collections
 ```
 
-or this collection should be installed locally with:  
+or this collection should be installed locally from its git source. This collection is distributed
+via GitHub releases and git tags rather than Ansible Galaxy:
 ```bash
-ansible-galaxy collection install -p ./collections influxdata.molecule
+ansible-galaxy collection install -p ./collections \
+  git+https://github.com/influxdata/ansible-collection-molecule.git,latest
 ```
 
-or if your `collections/requirements.yml` includes this collection:
+Pin whichever ref suits you:
+
+| Ref | Meaning |
+| --- | --- |
+| `latest` | The newest published release. Moved by the `Deploy Collection` workflow. |
+| `v<x.y.z>` | An immutable release tag, created when the `galaxy.yml` version is bumped on `main`. |
+| `main`, `devel` | That branch's head as of its last push. Unreleased, and force-moved on every push. |
+
+or if your `collections/requirements.yml` includes this collection as a git source:
 ```bash
 ansible-galaxy collection install -p ./collections -r ./collections/requirements.yml
 ```

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Pin whichever ref suits you:
 
 | Ref | Meaning |
 | --- | --- |
-| `latest` | The newest published release. Moved by the `Deploy Collection` workflow. |
+| `latest` | The newest published release. Always resolves to the same commit as some `v<x.y.z>` tag, never to a branch head. |
 | `v<x.y.z>` | An immutable release tag, created when the `galaxy.yml` version is bumped on `main`. |
 | `main`, `devel` | That branch's head as of its last push. Unreleased, and force-moved on every push. |
 


### PR DESCRIPTION
## Summary

`refs/tags/latest` has pointed at v2.0.1 (2025-03-07) for seventeen months. Anyone
pinning `latest` has been silently resolving that collection, not the current one.

- The `Tag latest release` step was gated on `GALAXY_DEPLOYMENT_ENABLED`, a flag
  that means "a `GALAXY_API_KEY` secret exists". No such secret is set in this repo.
- So every release since v2.0.1 skipped checkout, tagging, and publishing — and
  still reported success. The v2.2.0 run finished green in 27 seconds having done
  nothing.
- Publishing to Galaxy is optional. Tagging is not, and must not depend on it.

## Changes

### `.github/workflows/publish.yml`
- `Checkout repository` and `Tag latest release` no longer depend on the Galaxy key;
  only `Build and Deploy Collection` still does
- `GALAXY_DEPLOYMENT_ENABLED` is now `true`/`false`. It was `0` for enabled and `1`
  for disabled — inverted against its own name, which is what hid the miswiring
- `latest` now tracks the newest **release**, not the triggering ref. The tag is
  resolved first — the release's own tag on a release event, otherwise the newest
  non-prerelease — and that ref is checked out. `EndBug/latest-tag` tags whatever is
  checked out, so without this a dispatch run would have pointed `latest` at a branch
  head, duplicating the existing `main`/`devel` tags instead of naming a release
- Galaxy consequently builds from the release tag too, rather than the branch
- Added `workflow_dispatch`, so `latest` can be re-pointed without cutting a release.
  There was previously no way to recover from this stall
- The `prerelease == false` gate is unchanged and still correct on dispatch: the
  property is undefined there, and Actions coerces `null` and `false` alike to `0`

### `README.md`
- Install instructions used the Galaxy collection name, which cannot work while
  publishing is off. They now use the git source, matching what `roles/init` already
  generates by default (`init_collection_source: git`)
- Added a table naming the refs consumers can pin — `latest`, `v<x.y.z>`, and the
  branch tags — since that contract was written down nowhere

## Testing

No Molecule scenario applies; this is a release workflow and markdown. The fix is
verified by dispatching the workflow after merge: `Tag latest release` must report
`success` rather than `skipped`, while `Build and Deploy Collection` stays skipped
for the absent key. That dispatch also creates the `latest` tag for v2.2.0, and
`latest` must then dereference to v2.2.0's commit — not to `main`.
