### PR TITLE
chore: release 2.2.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,10 @@ on:
   release:
     types:
       - published
-  # Re-point `latest` at the newest release without cutting a new one.
+  # Re-point `latest` at the newest release without cutting a new one. Only works
+  # while that release's workflow files match main's — GITHUB_TOKEN cannot update a
+  # ref that changes .github/workflows/, and `workflows` is not a permission it can
+  # hold.
   workflow_dispatch:
 permissions:
   contents: read

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: influxdata
 name: molecule
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 2.2.0
+version: 2.2.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md


### PR DESCRIPTION
## Summary

Cuts a release from `main` so the `latest` tag can move. It is still on v2.0.1
(2025-03-07); #27 fixed the workflow but could not retroactively move the tag.

- `GITHUB_TOKEN` is refused when a ref update makes `.github/workflows/` differ
  from the default branch. v2.2.0 predates #27's edit to `publish.yml`, so
  pointing `latest` backwards at it is rejected — the catch-up dispatch failed
  exactly there.
- The restriction is directional, not a blanket ban: `build.yml` force-moves
  `refs/tags/main` on every push, including the #26 merge that edited
  `publish.yml`, because that tag lands on `main` HEAD where the files match.
- A release cut from `main` HEAD satisfies that by construction. `main` has no
  `v*` tag today, since `build.yml` mints one only on a version change.

Granting the permission is not an option — `workflows` is not a `GITHUB_TOKEN`
permission, so it would take a separate PAT or GitHub App held as a secret. Not
worth it: the normal release path needs no such token, `workflows: write` is
CI-rewrite capability, and a PAT's expiry would reintroduce the silent stall this
work exists to remove.

## Changes

- `galaxy.yml`: 2.2.0 → 2.2.1. Patch — the only change since v2.2.0 is #27, which
  is CI and documentation; no collection behaviour moves.
- `.github/workflows/publish.yml`: record on the `workflow_dispatch` trigger that
  re-pointing `latest` only works while the newest release's workflow files match
  `main`'s.

## Testing

No Molecule scenario applies; this is a version bump and a comment. Verified on
merge: `build.yml` must create tag `v2.2.1` at `main` HEAD, and publishing a
release for it must let `Tag latest release` report `success` rather than the
`remote rejected` seen in run 32773113058. `latest` must then dereference to
`v2.2.1`.
